### PR TITLE
nodetree.lua (format.new_line): Do a line break after `\par{}`

### DIFF
--- a/nodetree.lua
+++ b/nodetree.lua
@@ -187,7 +187,7 @@ local format = {
     end
     local new_line
     if options.channel == 'tex' then
-      new_line = '\\par{}'
+      new_line = '\\par\n'
     else
       new_line = '\n'
     end


### PR DESCRIPTION
There is no reason that the TeX channel output is a single, extremely long line.