### PR TITLE
nodetree.lua: Always show 'font' field

### DIFF
--- a/nodetree.lua
+++ b/nodetree.lua
@@ -1134,7 +1134,6 @@ function tree.format_field(head, field)
 
   if options.verbosity < 2 and
     -- glyph
-    field == 'font' or
     field == 'left' or
     field == 'right' or
     field == 'uchyph' or


### PR DESCRIPTION
This is probably a field most users would like to see (or rather, the changes thereof).

![image](https://github.com/Josef-Friedrich/nodetree/assets/1630245/7693935b-fbb0-4a2d-b082-e2426c3c9234)
